### PR TITLE
Fixed typo in JavaScript for redirection

### DIFF
--- a/flask_fastspring.py
+++ b/flask_fastspring.py
@@ -42,7 +42,7 @@ function fastspringOnPopupClosed(data) {
       if (xhr.status === 200) {
         window.location.replace("{{ request.url }}");
       } else if (xhr.status === 201 || (301 <= xhr.status && xhr.status <= 303)) {
-        window.location.replace(xhr.GetResponseHeader("Location"));
+        window.location.replace(xhr.getResponseHeader("Location"));
       } else {
         var message = "ERROR: Could not process order: " + data["reference"];
         console.log(message);


### PR DESCRIPTION
`xhr.getResponseHeader()` is correct method name.

Fixes #1 